### PR TITLE
Fix SVG coordinate formatting broken on non-English JVM locales  (Czech, German, etc.) 

### DIFF
--- a/src/scicloj/plotje/render/svg.clj
+++ b/src/scicloj/plotje/render/svg.clj
@@ -33,7 +33,9 @@
 (defn- fmt
   "Format a numeric value to 2 decimal places for SVG coordinates."
   [v]
-  (if v (format "%.2f" (double v)) "0.00"))
+  (if v
+    (String/format java.util.Locale/ROOT "%.2f" (to-array [(double v)]))
+    "0.00"))
 
 (defn- points->str
   "Convert a seq of [x y] pairs to SVG points attribute string."


### PR DESCRIPTION
Hi, this is my third PR in my whole life, so I hope it will work. I found a small bug leading to something like this:

<img width="490" height="451" alt="image" src="https://github.com/user-attachments/assets/8fe1229c-65c4-49d4-9b58-e9b98f0690b8" />

I cooperated with Claude and here is the solution. 

**plotje version:** 0.2.0

**Description:**
Charts render nearly empty when the JVM runs under a locale that uses a comma as the decimal separator (e.g. `cs_CZ`, `de_DE`).

**Root cause:**
`scicloj/plotje/render/svg.clj` formats SVG coordinates using `(format "%.2f" v)`, which is locale-sensitive. On Czech locale this produces `"12,00"` instead of `"12.00"`, turning a valid `translate(12.00,181.00)` into a malformed `translate(12,00,181,00)` with four arguments — breaking all point and axis placement.

**Minimal repro:**
```clojure
;; Start the JVM with Czech locale, e.g.: -Duser.language=cs -Duser.country=CZ
(require '[scicloj.metamorph.ml.rdatasets :as rdatasets]
         '[scicloj.plotje.api :as pj])

(-> (rdatasets/datasets-iris)
    (pj/lay-point :sepal-length :sepal-width))
;; => chart appears nearly empty; SVG contains translate(5,10,3,50) etc.
```

**Workaround:**
```clojure
(java.util.Locale/setDefault java.util.Locale/ROOT)
```
or add to deps.edn:
```edn
:jvm-opts ["-Duser.language=en" "-Duser.country=US"]
```

**Suggested fix sent in this PR:**
In `svg.clj`, the `fmt` helper has to be changed to pin the locale explicitly:
```clojure
(defn- fmt [v]
  (if v (String/format java.util.Locale/ROOT "%.2f" (to-array [(double v)])) "0.00"))
```

Best.