### PR TITLE
Suggestion only: new options :x-tick-angle and :x-tick-label-pad ?

### DIFF
--- a/src/scicloj/plotje/impl/defaults.clj
+++ b/src/scicloj/plotje/impl/defaults.clj
@@ -384,9 +384,7 @@
    :tick-spacing-x ["Ticks" "Minimum pixel spacing between x-axis ticks"]
    :tick-spacing-y ["Ticks" "Minimum pixel spacing between y-axis ticks"]
    :x-tick-angle ["Ticks" "Rotation angle for x-axis tick labels in degrees (0 = horizontal, -45 = common diagonal)"]
-   :x-tick-label-height ["Ticks" "Extra vertical space (px) reserved below panels for angled x-tick labels, added on top of :label-offset.
-                                  When nil, auto-computed from :x-tick-angle. When 0, no extra space is reserved and rotated labels may be 
-                                  clipped by the SVG boundary."]
+   :x-tick-label-pad ["Ticks" "Extra vertical space (px) reserved below panels for angled x-tick labels, added on top of :label-offset. When nil, auto-computed from :x-tick-angle. When 0, no extra space is reserved and rotated labels may be clipped by the SVG boundary."]
    :bin-method ["Statistics" "Histogram bin count method (:sturges, :sqrt, :rice, :fd)"]
    :domain-padding ["Statistics" "Fractional padding added to numeric domains"]
    :label-offset ["Labels" "Pixel offset for axis labels from the axis"]

--- a/src/scicloj/plotje/impl/defaults.clj
+++ b/src/scicloj/plotje/impl/defaults.clj
@@ -384,8 +384,9 @@
    :tick-spacing-x ["Ticks" "Minimum pixel spacing between x-axis ticks"]
    :tick-spacing-y ["Ticks" "Minimum pixel spacing between y-axis ticks"]
    :x-tick-angle ["Ticks" "Rotation angle for x-axis tick labels in degrees (0 = horizontal, -45 = common diagonal)"]
-   :x-tick-label-height ["Ticks" "Manual override for vertical space reserved below panels for x-tick labels (pixels); auto-computed
-   from :x-tick-angle when nil"]
+   :x-tick-label-height ["Ticks" "Extra vertical space (px) reserved below panels for angled x-tick labels, added on top of :label-offset.
+                                  When nil, auto-computed from :x-tick-angle. When 0, no extra space is reserved and rotated labels may be 
+                                  clipped by the SVG boundary."]
    :bin-method ["Statistics" "Histogram bin count method (:sturges, :sqrt, :rice, :fd)"]
    :domain-padding ["Statistics" "Fractional padding added to numeric domains"]
    :label-offset ["Labels" "Pixel offset for axis labels from the axis"]

--- a/src/scicloj/plotje/impl/defaults.clj
+++ b/src/scicloj/plotje/impl/defaults.clj
@@ -383,6 +383,9 @@
    :band-opacity ["Annotations" "Opacity for confidence bands"]
    :tick-spacing-x ["Ticks" "Minimum pixel spacing between x-axis ticks"]
    :tick-spacing-y ["Ticks" "Minimum pixel spacing between y-axis ticks"]
+   :x-tick-angle ["Ticks" "Rotation angle for x-axis tick labels in degrees (0 = horizontal, -45 = common diagonal)"]
+   :x-tick-label-height ["Ticks" "Manual override for vertical space reserved below panels for x-tick labels (pixels); auto-computed
+   from :x-tick-angle when nil"]
    :bin-method ["Statistics" "Histogram bin count method (:sturges, :sqrt, :rice, :fd)"]
    :domain-padding ["Statistics" "Fractional padding added to numeric domains"]
    :label-offset ["Labels" "Pixel offset for axis labels from the axis"]

--- a/src/scicloj/plotje/impl/layout.clj
+++ b/src/scicloj/plotje/impl/layout.clj
@@ -224,7 +224,7 @@
   (let [base (cond x-label? (:label-offset cfg)
                    :else (+ (tick-font-size cfg) 6))
         angle (get cfg :x-tick-angle 0)
-        extra (or (:x-tick-label-height cfg)
+        extra (or (:x-tick-label-pad cfg)
                   (+ (long (* 50 (Math/abs (Math/sin (Math/toRadians (double angle)))))) 
                      (if (zero? angle) 0 8)))]
     (+ base extra)))

--- a/src/scicloj/plotje/impl/layout.clj
+++ b/src/scicloj/plotje/impl/layout.clj
@@ -225,7 +225,8 @@
                    :else (+ (tick-font-size cfg) 6))
         angle (get cfg :x-tick-angle 0)
         extra (or (:x-tick-label-height cfg)
-                  (long (* 50 (Math/abs (Math/sin (Math/toRadians (double angle)))))))]
+                  (+ (long (* 50 (Math/abs (Math/sin (Math/toRadians (double angle)))))) 
+                     (if (zero? angle) 0 8)))]
     (+ base extra)))
 
 (defn- y-tick-text-width

--- a/src/scicloj/plotje/impl/layout.clj
+++ b/src/scicloj/plotje/impl/layout.clj
@@ -221,9 +221,12 @@
    room for the x-tick labels themselves; reserve tick-font-size
    plus a small padding."
   [{:keys [x-label?]} cfg]
-  (cond
-    x-label? (:label-offset cfg)
-    :else    (+ (tick-font-size cfg) 6)))
+  (let [base (cond x-label? (:label-offset cfg)
+                   :else (+ (tick-font-size cfg) 6))
+        angle (get cfg :x-tick-angle 0)
+        extra (or (:x-tick-label-height cfg)
+                  (long (* 50 (Math/abs (Math/sin (Math/toRadians (double angle)))))))]
+    (+ base extra)))
 
 (defn- y-tick-text-width
   "Over-estimate of the widest y-tick label in pixels. Runs the tick

--- a/src/scicloj/plotje/render/membrane.clj
+++ b/src/scicloj/plotje/render/membrane.clj
@@ -370,7 +370,7 @@
             ;; X-axis label
             (when x-label
               (let [fsize label-fsize]
-                [(ui/translate (+ y-label-pad (/ (* grid-cols pw) 2.0)) (- total-height x-label-pad -20)
+                [(ui/translate (+ y-label-pad (/ (* grid-cols pw) 2.0)) (- total-height (:label-offset cfg) #_x-label-pad -20)
                                (ui/with-color text-color
                                  (assoc (ui/label x-label (ui/font nil fsize))
                                         :text-anchor "middle")))]))

--- a/src/scicloj/plotje/render/panel.clj
+++ b/src/scicloj/plotje/render/panel.clj
@@ -85,8 +85,13 @@
                   (ui/translate (double px)
                                 (+ (double ph) 2)
                                 (ui/with-color tick-color
-                                  (assoc (ui/label label (ui/font nil fsize))
-                                         :text-anchor "middle"))))
+                                  (let [angle (get cfg :x-tick-angle 0)]
+                                    (if (zero? angle)
+                                      (assoc (ui/label label (ui/font nil fsize))
+                                             :text-anchor "middle")
+                                      (membrane.ui.Rotate. (double angle)
+                                                           (assoc (ui/label label (ui/font nil fsize))
+                                                                  :text-anchor (if (neg? angle) "end" "start"))))))))
                 (let [py (scale t)]
                   (ui/translate (- (double m) 3)
                                 (- (double py) (/ fsize 2.0))

--- a/src/scicloj/plotje/render/svg.clj
+++ b/src/scicloj/plotje/render/svg.clj
@@ -33,7 +33,9 @@
 (defn- fmt
   "Format a numeric value to 2 decimal places for SVG coordinates."
   [v]
-  (if v (format "%.2f" (double v)) "0.00"))
+  (if v
+    (String/format java.util.Locale/ROOT "%.2f" (to-array [(double v)]))
+    "0.00"))
 
 (defn- points->str
   "Convert a seq of [x y] pairs to SVG points attribute string."


### PR DESCRIPTION
Hello @daslu, 
instead of not doing it, I could not help trying it so I thought about and tried to overcome an issue with (sometimes) overlapping x-tick labels:

<img width="1560" height="950" alt="CleanShot 2026-05-14 at 10 11 25@2x" src="https://github.com/user-attachments/assets/a8507452-49df-4031-b6b9-83caabecb1bb" />

In my local repo, I implemented the addition of two new options: `:x-tick-angle` and `:x-tick-label-pad`, which allows adding an angle to tick labels and renders them rotated. By default, it works as usual. Adding non-zero `:x-tick-angle` value to `pj/options` renders the effect.

The space below rotated ticks is extended via `(* 50 (Math/abs (Math/sin (Math/toRadians (double angle)))))` to calculate the height, where 50 is just a guess on how long in pixels an average label is. For many usecases I tried it works well. 

This is my real-world chart with `:x-tick-angle` defined: `-45`

```clojure
(-> ds
    (tc/pivot->longer [:empty-lists-created :non-empty-lists-created] {:target-columns :series :value-column-name :value})
    (pj/lay-value-bar :date :value {:color :series :position :dodge})
    (pj/options {:width 800 :height 450
                 :title "Počet vytvořených todos"
                 :x-label "Datum"
                 :y-label "Todos"
                 :x-tick-angle -45}))
```

<img width="1582" height="976" alt="CleanShot 2026-05-14 at 10 11 54@2x" src="https://github.com/user-attachments/assets/4a317545-d224-4a68-882c-7dd16b03efe4" />

Here it is with `:x-tick-angle` = `45`

<img width="1592" height="944" alt="CleanShot 2026-05-14 at 10 11 03@2x" src="https://github.com/user-attachments/assets/65306710-0fea-46f4-9511-1b760b7624be" />

And finally, here I show what application of `:x-tick-label-pad` (e.g. value `100`) seems like:

<img width="1534" height="950" alt="CleanShot 2026-05-14 at 10 19 33@2x" src="https://github.com/user-attachments/assets/44182ed9-99bf-4ea4-a414-338039bddad8" />

I run tests in the project and tested several visual edge cases, it works. Tests fail only on checking the number of `config-key-docs` keys, which is now 16, not 14. It does not seem they are breaking changes introduced by this anywhere.

I got help from docs and Claude when learning how plotje works and where to find the places to implement changes. Then I wrote or re-wrote all code by myself into namespaces and repeatedly checked for understanding of underlying principles of the library to be sure I am doing it right. Still, I know, it is possible that I messed it up. 